### PR TITLE
feat: add feature serde_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ repository = "LinkTed/dns-message-parser"
 branch = "master"
 service = "github"
 
+[features]
+serde_derive = ["serde"]
+
 [dependencies]
 num-derive = "0.3.0"
 num-traits = "0.2.12"
@@ -35,3 +38,4 @@ regex = "1.3.9"
 lazy_static = "1.4.0"
 getset = "0.1.1"
 hex = "0.4.2"
+serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -2,6 +2,7 @@ use crate::{Opcode, Question, RCode, RR};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, Copy, Clone, Getters, Setters, PartialEq)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub struct Flags {
     pub qr: bool,
     pub opcode: Opcode,

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,4 +1,8 @@
 use crate::{Opcode, Question, RCode, RR};
+
+#[cfg(feature = "serde_derive")]
+use serde::{Deserialize, Serialize};
+
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, Copy, Clone, Getters, Setters, PartialEq)]

--- a/src/domain_name.rs
+++ b/src/domain_name.rs
@@ -2,6 +2,8 @@ use std::convert::TryFrom;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use regex::Regex;
+#[cfg(feature = "serde_derive")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DomainError {
@@ -11,6 +13,7 @@ pub enum DomainError {
 }
 
 #[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub struct DomainName {
     pub(crate) domain_name: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,13 @@ pub use resource_record::{RData, RR};
 mod question;
 pub use question::{QClass, QClass_, QType, QType_, Question};
 
+#[cfg(feature = "serde_derive")]
+use serde::{Serialize, Deserialize};
+
 pub const MAXIMUM_DNS_PACKET_SIZE: usize = 65536;
 
 #[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum Opcode {
     Query = 0,
     IQuery = 1,
@@ -37,6 +41,7 @@ pub enum Opcode {
 }
 
 #[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum RCode {
     NoError = 0,
     FormErr = 1,
@@ -62,6 +67,7 @@ pub enum RCode {
 }
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum Type {
     A = 1,
     NS = 2,
@@ -155,6 +161,7 @@ pub enum Type {
 }
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum Class {
     IN = 1,
 
@@ -165,12 +172,14 @@ pub enum Class {
 }
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum AFSDBSubtype {
     VolumeLocationServer = 1,
     DCEAuthenticationServer = 2,
 }
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum SSHFPAlgorithm {
     Reserved = 0,
     RSA = 1,
@@ -178,6 +187,7 @@ pub enum SSHFPAlgorithm {
 }
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum SSHFPType {
     Reserved = 0,
     Sha1 = 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod question;
 pub use question::{QClass, QClass_, QType, QType_, Question};
 
 #[cfg(feature = "serde_derive")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 pub const MAXIMUM_DNS_PACKET_SIZE: usize = 65536;
 

--- a/src/question.rs
+++ b/src/question.rs
@@ -1,5 +1,8 @@
 use crate::{Class, DomainName, Type};
 
+#[cfg(feature = "serde_derive")]
+use serde::{Deserialize, Serialize};
+
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq, Eq, Hash)]

--- a/src/question.rs
+++ b/src/question.rs
@@ -3,6 +3,7 @@ use crate::{Class, DomainName, Type};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum QType_ {
     AXFR = 252,
     MAILB = 253,
@@ -11,6 +12,7 @@ pub enum QType_ {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum QType {
     Type(Type),
     QType(QType_),
@@ -26,11 +28,13 @@ impl Display for QType {
 }
 
 #[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum QClass_ {
     ANY = 255,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum QClass {
     Class(Class),
     QClass(QClass_),

--- a/src/resource_record.rs
+++ b/src/resource_record.rs
@@ -3,6 +3,8 @@ use crate::{
 };
 
 use hex::encode as hex_encode;
+#[cfg(feature = "serde_derive")]
+use serde::{Deserialize, Serialize};
 
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/src/resource_record.rs
+++ b/src/resource_record.rs
@@ -8,6 +8,7 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde_derive", derive(Serialize, Deserialize))]
 pub enum RData {
     A(Ipv4Addr),
     NS(DomainName),


### PR DESCRIPTION
dns-over-https has JSON format, If we can serialize `dns-message-parser` struct to JSON, that will be more user-friendly.