### PR TITLE
Support SVCB and HTTPS Resource Records

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ categories = [
     ]
 
 [dependencies]
+base64 = "~0.13"
 bytes = "~1.0"
 hex = "~0.4"
 thiserror = "~1.0"

--- a/src/decode/error.rs
+++ b/src/decode/error.rs
@@ -93,4 +93,6 @@ pub enum DecodeError {
     PaddingLength(usize),
     #[error("Could not decode Tag: {0}")]
     TagError(#[from] TagError),
+    #[error("ECH length mismatch. Expected {0} got {1}")]
+    ECHLengthMismatch(usize, usize),
 }

--- a/src/decode/rr/draft_ietf_dnsop_svcb_https.rs
+++ b/src/decode/rr/draft_ietf_dnsop_svcb_https.rs
@@ -1,0 +1,114 @@
+use crate::decode::error::DecodeError::ECHLengthMismatch;
+use crate::decode::Decoder;
+use crate::rr::{ServiceBinding, ServiceParameter};
+use crate::DecodeResult;
+
+use super::Header;
+use std::collections::BTreeSet;
+
+impl<'a, 'b: 'a> Decoder<'b, 'b> {
+    /// Decode a Service Binding (SVCB or HTTP) resource record
+    ///
+    /// Preconditions
+    /// * The header and question sections should have already been decoded. Specifically, index of
+    ///   any previously-identified domain names must already be captured.
+    ///
+    /// Parameters
+    /// - `header` - the header that precedes the question section
+    /// - `https` - true for `HTTPS` resource records, false for `SVCB`
+    pub(super) fn rr_service_binding(
+        &'a mut self,
+        header: Header,
+        https: bool,
+    ) -> DecodeResult<ServiceBinding> {
+        let priority = self.u16()?;
+        let target_name = self.domain_name()?;
+        let mut parameters = BTreeSet::new();
+        if priority != 0 {
+            while !self.is_finished()? {
+                let service_parameter_key = self.u16()?;
+                let value_length = self.u16()?;
+                let mut parameter_decoder = self.sub(value_length)?;
+                let service_parameter =
+                    parameter_decoder.rr_service_parameter(service_parameter_key)?;
+                parameter_decoder.finished()?;
+
+                parameters.insert(service_parameter);
+            }
+        }
+        Ok(ServiceBinding {
+            name: header.domain_name,
+            ttl: header.ttl,
+            priority,
+            target_name,
+            parameters,
+            https,
+        })
+    }
+}
+
+impl<'a, 'b: 'a> Decoder<'a, 'b> {
+    /// Decode a single service parameter
+    ///
+    /// Parameters:
+    /// - `service_parameter_key` - the IANA-controlled numeric identifier as defined in section
+    ///                             14.3 of the RFC
+    ///
+    /// Returns:
+    /// - `Ok(ServiceParameter)` - if there were no issues decoding the value
+    /// - `Err` - if there was any decoding error
+    fn rr_service_parameter(
+        &mut self,
+        service_parameter_key: u16,
+    ) -> DecodeResult<ServiceParameter> {
+        let service_parameter = match service_parameter_key {
+            0 => {
+                let mut key_ids = vec![];
+                while !self.is_finished()? {
+                    key_ids.push(self.u16()?);
+                }
+                ServiceParameter::MANDATORY { key_ids }
+            }
+            1 => {
+                let mut alpn_ids = vec![];
+                while !self.is_finished()? {
+                    alpn_ids.push(self.string()?);
+                }
+                ServiceParameter::ALPN { alpn_ids }
+            }
+            2 => ServiceParameter::NO_DEFAULT_ALPN,
+            3 => ServiceParameter::PORT { port: self.u16()? },
+            4 => {
+                let mut hints = vec![];
+                while !self.is_finished()? {
+                    hints.push(self.ipv4_addr()?);
+                }
+                ServiceParameter::IPV4_HINT { hints }
+            }
+            5 => {
+                // Note the RFC does not explicitly state that the length is two octets
+                // "In wire format, the value of the parameter is an ECHConfigList [ECH],
+                // including the redundant length prefix." - RFC Section 9
+                let length = self.u16()? as usize;
+                let config_list = self.vec()?;
+                if config_list.len() != length {
+                    return Err(ECHLengthMismatch(length, config_list.len()));
+                }
+                ServiceParameter::ECH { config_list }
+            }
+            6 => {
+                let mut hints = vec![];
+                while !self.is_finished()? {
+                    hints.push(self.ipv6_addr()?);
+                }
+                ServiceParameter::IPV6_HINT { hints }
+            }
+            65535 => ServiceParameter::KEY_65535,
+            number => ServiceParameter::PRIVATE {
+                number,
+                wire_data: self.vec()?,
+            },
+        };
+        Ok(service_parameter)
+    }
+}

--- a/src/decode/rr/enums.rs
+++ b/src/decode/rr/enums.rs
@@ -73,6 +73,8 @@ impl<'a, 'b: 'a> Decoder<'b, 'b> {
             Type::DNSKEY => RR::DNSKEY(r_data.rr_dnskey(header)?),
             Type::DS => RR::DS(r_data.rr_ds(header)?),
             Type::CAA => RR::CAA(r_data.rr_caa(header)?),
+            Type::SVCB => RR::SVCB(r_data.rr_service_binding(header, false)?),
+            Type::HTTPS => RR::HTTPS(r_data.rr_service_binding(header, true)?),
             type_ => return Err(DecodeError::NotYetImplemented(type_)),
         };
         r_data.finished()?;

--- a/src/decode/rr/mod.rs
+++ b/src/decode/rr/mod.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 mod macros;
+mod draft_ietf_dnsop_svcb_https;
 mod edns;
 mod enums;
 mod rfc_1035;

--- a/src/decode/rr/tests.rs
+++ b/src/decode/rr/tests.rs
@@ -1,5 +1,12 @@
 use super::Header;
+use crate::decode::decoder::Decoder;
+use crate::decode::error::DecodeError::ECHLengthMismatch;
+use crate::rr::ServiceParameter;
 use crate::{DecodeError, DomainName};
+use bytes::Bytes;
+use std::convert::TryFrom;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
 
 #[test]
 fn header_get_class_error() {
@@ -9,4 +16,370 @@ fn header_get_class_error() {
         ttl: 1000,
     };
     assert_eq!(header.get_class(), Err(DecodeError::Class(u16::MAX)));
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#aliasform
+#[test]
+fn test_service_binding_alias_form() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x00"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03com\x00"); // target
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 0);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("foo.example.com").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert!(result.parameters.is_empty());
+    assert!(result.to_string().ends_with("0 foo.example.com."));
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_use_the_ownername() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x01"); // priority
+    bytes.extend_from_slice(b"\x00"); // target (root label)
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 1);
+    assert_eq!(result.target_name, DomainName::try_from(".").unwrap());
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert!(result.parameters.is_empty());
+    assert!(result.to_string().ends_with("1 ."));
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_map_port() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x10"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03com\x00"); // target
+    bytes.extend_from_slice(b"\x00\x03"); // key 3 (port)
+    bytes.extend_from_slice(b"\x00\x02"); // value length: 2 bytes (2 octets)
+    bytes.extend_from_slice(b"\x00\x35"); // value: 53
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 16);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("foo.example.com").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert_eq!(result.parameters.len(), 1);
+    assert!(matches!(result.parameters.iter().next().unwrap(),
+        ServiceParameter::PORT {port} if *port == 53));
+    assert!(result.to_string().ends_with("16 foo.example.com. port=53"));
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_unregistered_key() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x01"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03com\x00"); // target
+    bytes.extend_from_slice(b"\x02\x9b"); // key 667 (unregistered)
+    bytes.extend_from_slice(b"\x00\x05"); // value length: 5 bytes (2 octets)
+    bytes.extend_from_slice(b"hello"); // value
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 1);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("foo.example.com").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert_eq!(result.parameters.len(), 1);
+    assert!(matches!(result.parameters.iter().next().unwrap(),
+            ServiceParameter::PRIVATE { number, wire_data, } if *number == 667
+                && String::from_utf8(wire_data.clone()).unwrap() == *"hello"))
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_unregistered_key_escaped_value() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x01"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03com\x00"); // target
+    bytes.extend_from_slice(b"\x02\x9b"); // key 667 (unregistered)
+    bytes.extend_from_slice(b"\x00\x09"); // value length: 9 bytes (2 octets)
+    bytes.extend_from_slice(b"hello\xd2qoo"); // value
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 1);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("foo.example.com").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert_eq!(result.parameters.len(), 1);
+    assert!(matches!(result.parameters.iter().next().unwrap(),
+            ServiceParameter::PRIVATE { number, wire_data, } if *number == 667
+                && wire_data.as_slice() == b"hello\xd2qoo"));
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_ipv6_hints() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x01"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03com\x00"); // target
+    bytes.extend_from_slice(b"\x00\x06"); // key 6 (IPv6 hint)
+    bytes.extend_from_slice(b"\x00\x20"); // value length: 32 bytes (2 octets)
+    bytes.extend_from_slice(b"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"); // first address
+    bytes.extend_from_slice(b"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x53\x00\x01"); // second address
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 1);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("foo.example.com").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert_eq!(result.parameters.len(), 1);
+    assert!(matches!(result.parameters.iter().next().unwrap(),
+            ServiceParameter::IPV6_HINT { hints } if hints.len() == 2
+                && hints[0] == Ipv6Addr::from_str("2001:db8::1").unwrap()
+                && hints[1] == Ipv6Addr::from_str("2001:db8::53:1").unwrap()));
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_ipv6_in_ipv4_mapped_ipv6_format() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x01"); // priority
+    bytes.extend_from_slice(b"\x07example\x03com\x00"); // target
+    bytes.extend_from_slice(b"\x00\x06"); // key 6 (IPv6 hint)
+    bytes.extend_from_slice(b"\x00\x10"); // value length: 16 bytes (2 octets)
+    bytes.extend_from_slice(b"\x20\x01\x0d\xb8\xff\xff\xff\xff\xff\xff\xff\xff\xc6\x33\x64\x64"); // address
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 1);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("example.com").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert_eq!(result.parameters.len(), 1);
+    assert!(matches!(result.parameters.iter().next().unwrap(),
+             ServiceParameter::IPV6_HINT { hints } if hints.len() == 1 && hints[0] == Ipv6Addr::from_str("2001:db8:ffff:ffff:ffff:ffff:198.51.100.100").unwrap()))
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_multiple_parameters() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x10"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03org\x00"); // target
+
+    // parameters are deliberately presented in the incorrect order
+    // they will be sorted correctly when they are deserialised
+    bytes.extend_from_slice(b"\x00\x01"); // key 1 (alpn)
+    bytes.extend_from_slice(b"\x00\x09"); // alpn value length: 9 bytes (2 octets)
+    bytes.extend_from_slice(b"\x02"); // alpn[0] length: 2 bytes (1 octet)
+    bytes.extend_from_slice(b"h2"); // alpn[0] = h2
+    bytes.extend_from_slice(b"\x05"); // alpn[1] length: 5 bytes (1 octet)
+    bytes.extend_from_slice(b"h3-19"); // alpn[1] = h3-19
+    bytes.extend_from_slice(b"\x00\x00"); // key 0 (mandatory)
+    bytes.extend_from_slice(b"\x00\x02"); // value length: 2 bytes (2 octets)
+    bytes.extend_from_slice(b"\x00\x01"); // value: key 1
+    bytes.extend_from_slice(b"\x00\x04"); // key 4 (IPv4 hint)
+    bytes.extend_from_slice(b"\x00\x04"); // hint length: 4 bytes (2 octets)
+    bytes.extend_from_slice(b"\xc0\x00\x02\x01"); // IPv4 address
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 16);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("foo.example.org").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert_eq!(result.parameters.len(), 3);
+    let mut parameters = result.parameters.iter();
+    assert!(matches!(parameters.next().unwrap(),
+            ServiceParameter::MANDATORY{ key_ids } if key_ids.len() == 1 && key_ids[ 0 ] == 1 ));
+    assert!(matches!(parameters.next().unwrap(),
+            ServiceParameter::ALPN { alpn_ids } if alpn_ids.len() == 2 && alpn_ids[0] == "h2" && alpn_ids[1] == "h3-19"));
+    assert!(matches!(parameters.next().unwrap(),
+            ServiceParameter::IPV4_HINT { hints } if hints.len() == 1 && hints[0] == Ipv4Addr::from_str("192.0.2.1").unwrap()));
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_escaped_presentation_format() {
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x10"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03org\x00"); // target
+    bytes.extend_from_slice(b"\x00\x01"); // key 1 (alpn)
+    bytes.extend_from_slice(b"\x00\x0c"); // param length 12
+    bytes.extend_from_slice(b"\x08"); // alpn[0] length 8
+    bytes.extend_from_slice(b"f\\oo,bar"); // alpn[0]
+    bytes.extend_from_slice(b"\x02"); // alpn[1] length 2
+    bytes.extend_from_slice(b"h2"); // alpn[1]
+
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false).unwrap();
+
+    // then
+    assert_eq!(result.priority, 16);
+    assert_eq!(
+        result.target_name,
+        DomainName::try_from("foo.example.org").unwrap()
+    );
+    assert_eq!(result.ttl, 7200);
+    assert_eq!(
+        result.name,
+        DomainName::try_from("test.example.com").unwrap()
+    );
+    assert_eq!(result.parameters.len(), 1);
+    assert!(matches!(result.parameters.iter().next().unwrap(),
+            ServiceParameter::ALPN { alpn_ids } if alpn_ids.len() == 2 && alpn_ids[0] == "f\\oo,bar" && alpn_ids[1] == "h2"));
+}
+
+#[test]
+fn test_service_binding_ech_length_mismatch() {
+    // given
+    let mut bytes: Vec<u8> = vec![];
+    bytes.extend_from_slice(b"\x00\x01"); // priority
+    bytes.extend_from_slice(b"\x03foo\x07example\x03com\x00"); // target
+    bytes.extend_from_slice(b"\x00\x05"); // key 5 (ECH)
+    bytes.extend_from_slice(b"\x00\x07"); // value length: 7 bytes (2 octets)
+    bytes.extend_from_slice(b"\x00\x07"); // (incorrect) ECHConfigList length: 7 bytes (2 octets)
+    bytes.extend_from_slice(b"Hello"); // value
+    let mut decoder = Decoder::main(Bytes::from(bytes));
+    let header = Header {
+        domain_name: DomainName::try_from("test.example.com").unwrap(),
+        class: 1,
+        ttl: 7200,
+    };
+
+    // when
+    let result = decoder.rr_service_binding(header, false);
+
+    // then
+    assert!(matches!(result,
+        Err(decode_error) if matches!(decode_error,
+            ECHLengthMismatch(expected, actual) if expected == 7 && actual == 5)));
 }

--- a/src/encode/rr/draft_ietf_dnsop_svcb_https.rs
+++ b/src/encode/rr/draft_ietf_dnsop_svcb_https.rs
@@ -1,0 +1,84 @@
+use crate::encode::Encoder;
+use crate::rr::{Class, ServiceBinding, ServiceBindingMode, ServiceParameter, Type};
+use crate::{EncodeError, EncodeResult};
+
+impl Encoder {
+    /// Encode a service binding (SVCB or HTTPS) resource record
+    pub(super) fn rr_service_binding(
+        &mut self,
+        service_binding: &ServiceBinding,
+    ) -> EncodeResult<()> {
+        let rr_type = if service_binding.https {
+            &Type::HTTPS
+        } else {
+            &Type::SVCB
+        };
+        self.domain_name(&service_binding.name)?;
+        self.rr_type(rr_type);
+        self.rr_class(&Class::IN);
+        self.u32(service_binding.ttl);
+
+        // RDATA wire format: RFC section 2.2
+        let length_index = self.create_length_index();
+        self.u16(service_binding.priority);
+        self.domain_name(&service_binding.target_name)?;
+        if service_binding.mode() == ServiceBindingMode::Service {
+            for parameter in &service_binding.parameters {
+                self.rr_service_parameter(parameter)?;
+            }
+        }
+        self.set_length_index(length_index)
+    }
+
+    /// Encode a single service parameter
+    fn rr_service_parameter(&mut self, parameter: &ServiceParameter) -> EncodeResult<()> {
+        self.u16(parameter.get_registered_number());
+        let length_index = self.create_length_index();
+        match parameter {
+            ServiceParameter::MANDATORY { key_ids } => {
+                let mut key_ids = key_ids.clone();
+                key_ids.sort_unstable();
+                for key_id in key_ids {
+                    self.u16(key_id);
+                }
+            }
+            ServiceParameter::ALPN { alpn_ids } => {
+                for alpn_id in alpn_ids {
+                    self.string(alpn_id)?;
+                }
+            }
+            ServiceParameter::NO_DEFAULT_ALPN => {}
+            ServiceParameter::PORT { port } => {
+                self.u16(*port);
+            }
+            ServiceParameter::IPV4_HINT { hints } => {
+                for hint in hints {
+                    self.ipv4_addr(hint);
+                }
+            }
+            ServiceParameter::ECH { config_list } => {
+                if config_list.len() > u16::MAX as usize {
+                    return Err(EncodeError::Length(config_list.len()));
+                }
+                // Note the RFC does not explicitly state that the length is two octets
+                // "In wire format, the value of the parameter is an ECHConfigList [ECH],
+                // including the redundant length prefix." - RFC Section 9
+                self.u16(config_list.len() as u16);
+                self.vec(config_list);
+            }
+            ServiceParameter::IPV6_HINT { hints } => {
+                for hint in hints {
+                    self.ipv6_addr(hint);
+                }
+            }
+            ServiceParameter::PRIVATE {
+                number: _,
+                wire_data,
+            } => {
+                self.vec(wire_data);
+            }
+            ServiceParameter::KEY_65535 => {}
+        }
+        self.set_length_index(length_index)
+    }
+}

--- a/src/encode/rr/enums.rs
+++ b/src/encode/rr/enums.rs
@@ -59,6 +59,8 @@ impl Encoder {
             RR::DNSKEY(dnskey) => self.rr_dnskey(dnskey),
             RR::DS(ds) => self.rr_ds(ds),
             RR::CAA(caa) => self.rr_caa(caa),
+            RR::SVCB(svcb) => self.rr_service_binding(svcb),
+            RR::HTTPS(https) => self.rr_service_binding(https),
         }
     }
 }

--- a/src/encode/rr/mod.rs
+++ b/src/encode/rr/mod.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 mod macros;
+mod draft_ietf_dnsop_svcb_https;
 mod edns;
 mod enums;
 mod rfc_1035;
@@ -20,4 +21,6 @@ mod rfc_7043;
 mod rfc_7553;
 mod rfc_8659;
 mod subtypes;
+#[cfg(test)]
+mod tests;
 mod unknown;

--- a/src/encode/rr/tests.rs
+++ b/src/encode/rr/tests.rs
@@ -1,0 +1,408 @@
+use std::convert::TryFrom;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use crate::encode::encoder::Encoder;
+use crate::question::QType::{HTTPS, SVCB};
+use crate::question::{QClass, Question};
+use crate::rr::{ServiceBinding, ServiceBindingMode, ServiceParameter, RR};
+use crate::{Dns, DomainName, Flags, Opcode, RCode};
+use std::collections::BTreeSet;
+
+#[test]
+fn test_service_binding_encode_decode() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("_8765._baz.api.test").unwrap();
+    let target_name = DomainName::try_from("svc4-baz.test").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 7200,
+        priority: 0,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xeced, service_binding);
+
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let result = Dns::decode(encoder.bytes.freeze()).expect("Unable to parse encoded DNS");
+    assert_eq!(result.answers.len(), 1);
+    let answer = &result.answers[0];
+    assert!(
+        matches!(answer, RR::SVCB(service_binding) if service_binding.mode() == ServiceBindingMode::Alias)
+    )
+}
+
+/// Example from https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#aliasform
+#[test]
+fn test_service_binding_alias_form() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 0,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xcccd, service_binding);
+
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x00"); // priority
+    expected.extend_from_slice(b"\x03foo"); // target subdomain (new data)
+    expected.extend_from_slice(b"\xc0\x0c"); // target parent domain (compressed format, first appears at index 12)
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_use_the_owername() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.test").unwrap();
+    let target_name = DomainName::default();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 7200,
+        priority: 1,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xccce, service_binding);
+
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - 3);
+    assert_eq!(suffix, b"\x00\x01\x00");
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_map_port() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 16,
+        target_name,
+        parameters: vec![ServiceParameter::PORT { port: 53 }]
+            .into_iter()
+            .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xcddc, service_binding);
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x10"); // priority
+    expected.extend_from_slice(b"\x03foo"); // target subdomain (new data)
+    expected.extend_from_slice(b"\xc0\x0c"); // target parent domain (compressed format, first appears at index 12)
+    expected.extend_from_slice(b"\x00\x03"); // key 3 (port)
+    expected.extend_from_slice(b"\x00\x02"); // value length (2 bytes)
+    expected.extend_from_slice(b"\x00\x35"); // value (port 53)
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_unregistered_key_value() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 16,
+        target_name,
+        parameters: vec![ServiceParameter::PRIVATE {
+            number: 667,
+            wire_data: b"hello".to_vec(),
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xcfcc, service_binding);
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x10"); // priority
+    expected.extend_from_slice(b"\x03foo"); // target subdomain (new data)
+    expected.extend_from_slice(b"\xc0\x0c"); // target parent domain (compressed format, first appears at index 12)
+    expected.extend_from_slice(b"\x02\x9b"); // key 667
+    expected.extend_from_slice(b"\x00\x05"); // value length (5)
+    expected.extend_from_slice(b"hello"); // value
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_unregistered_key_unquoted_value() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: vec![ServiceParameter::PRIVATE {
+            number: 667,
+            wire_data: b"hello\xd2qoo".to_vec(),
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xdffd, service_binding);
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x01"); // priority
+    expected.extend_from_slice(b"\x03foo"); // target subdomain (new data)
+    expected.extend_from_slice(b"\xc0\x0c"); // target parent domain (compressed format, first appears at index 12)
+    expected.extend_from_slice(b"\x02\x9b"); // key 667
+    expected.extend_from_slice(b"\x00\x09"); // value length (5)
+    expected.extend_from_slice(b"hello\xd2qoo"); // value
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_ipv6_hints() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: vec![ServiceParameter::IPV6_HINT {
+            hints: vec![
+                Ipv6Addr::from_str("2001:db8::1").unwrap(),
+                Ipv6Addr::from_str("2001:db8::53:1").unwrap(),
+            ],
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xacca, service_binding);
+
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x01"); // priority
+    expected.extend_from_slice(b"\x03foo"); // target subdomain (new data)
+    expected.extend_from_slice(b"\xc0\x0c"); // target parent domain (compressed format, first appears at index 12)
+    expected.extend_from_slice(b"\x00\x06"); // key 6 (IPv6 hints)
+    expected.extend_from_slice(b"\x00\x20"); // length 32
+    expected.extend_from_slice(b"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"); // first IP address
+    expected.extend_from_slice(b"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00\x53\x00\x01"); // second IP address
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_ipv6_hint_in_ipv4_mapped_ipv6_presentation_format() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: vec![ServiceParameter::IPV6_HINT {
+            hints: vec![Ipv6Addr::from_str("2001:db8:ffff:ffff:ffff:ffff:198.51.100.100").unwrap()],
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xaedc, service_binding);
+
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x01"); // priority
+    expected.extend_from_slice(b"\xc0\x0c"); // target domain (compressed format, first appears at index 12)
+    expected.extend_from_slice(b"\x00\x06"); // key 6 (IPv6 hints)
+    expected.extend_from_slice(b"\x00\x10"); // length 16
+    expected.extend_from_slice(b"\x20\x01\x0d\xb8\xff\xff\xff\xff\xff\xff\xff\xff\xc6\x33\x64\x64"); // IP address
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_sort_multiple_parameters() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.org").unwrap();
+    let target_name = DomainName::try_from("foo.example.org").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 16,
+        target_name,
+        // parameters are deliberately presented in the incorrect order
+        // they will be sorted correctly prior to sending over the wire
+        parameters: vec![
+            ServiceParameter::ALPN {
+                alpn_ids: vec!["h2".to_string(), "h3-19".to_string()],
+            },
+            ServiceParameter::MANDATORY {
+                key_ids: vec![4, 1],
+            },
+            ServiceParameter::IPV4_HINT {
+                hints: vec![Ipv4Addr::from_str("192.0.2.1").unwrap()],
+            },
+        ]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xadda, service_binding);
+
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x10"); // priority
+    expected.extend_from_slice(b"\x03foo"); // target subdomain (new data)
+    expected.extend_from_slice(b"\xc0\x0c"); // target parent domain (compressed format, first appears at index 12)
+    expected.extend_from_slice(b"\x00\x00"); // key 0 (mandatory keys)
+    expected.extend_from_slice(b"\x00\x04"); // value length (2 mandatory keys)
+    expected.extend_from_slice(b"\x00\x01"); // alpn is mandatory
+    expected.extend_from_slice(b"\x00\x04"); // ipv4hint is mandatory
+    expected.extend_from_slice(b"\x00\x01"); // key 1 (alpn)
+    expected.extend_from_slice(b"\x00\x09"); // value length (9)
+    expected.extend_from_slice(b"\x02"); // alpn ID length (2)
+    expected.extend_from_slice(b"h2"); // alpn_ids[0] = h2
+    expected.extend_from_slice(b"\x05"); // alpn ID length (2)
+    expected.extend_from_slice(b"h3-19"); // alpn_ids[1] = h3-19
+    expected.extend_from_slice(b"\x00\x04"); // key 4 (ipv4hint)
+    expected.extend_from_slice(b"\x00\x04"); // value length 4 (1 IPv4 address)
+    expected.extend_from_slice(b"\xc0\x00\x02\x01"); // IP address
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_service_binding_alpn_with_escaped_values() {
+    // given
+    let mut encoder = Encoder::default();
+    let domain_name = DomainName::try_from("example.org").unwrap();
+    let target_name = DomainName::try_from("foo.example.org").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 16,
+        target_name,
+        parameters: vec![ServiceParameter::ALPN {
+            alpn_ids: vec!["f\\oo,bar".to_string(), "h2".to_string()],
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+    let dns = service_binding_dns(0xdfaf, service_binding);
+
+    // when
+    encoder.dns(&dns).unwrap();
+
+    // then
+    let mut expected = vec![];
+    expected.extend_from_slice(b"\x00\x10"); // priority
+    expected.extend_from_slice(b"\x03foo"); // target subdomain (new data)
+    expected.extend_from_slice(b"\xc0\x0c"); // target parent domain (compressed format, first appears at index 12)
+    expected.extend_from_slice(b"\x00\x01"); // key 1 (alpn)
+    expected.extend_from_slice(b"\x00\x0c"); // value length (12)
+    expected.extend_from_slice(b"\x08"); // alpn ID length (8)
+    expected.extend_from_slice(b"f\\oo,bar"); // alpn_ids[0] = f\oo,bar
+    expected.extend_from_slice(b"\x02"); // alpn ID length (2)
+    expected.extend_from_slice(b"h2"); // alpn_ids[1] = h2
+
+    let (_, suffix) = encoder.bytes.split_at(encoder.bytes.len() - expected.len());
+    assert_eq!(suffix, expected.as_slice());
+}
+
+fn service_binding_dns(id: u16, service_binding: ServiceBinding) -> Dns {
+    Dns {
+        id,
+        flags: response_flag(),
+        questions: vec![Question {
+            domain_name: service_binding.name.to_owned(),
+            q_class: QClass::IN,
+            q_type: if service_binding.https { HTTPS } else { SVCB },
+        }],
+        answers: vec![if service_binding.https {
+            RR::HTTPS(service_binding)
+        } else {
+            RR::SVCB(service_binding)
+        }],
+        authorities: vec![],
+        additionals: vec![],
+    }
+}
+
+fn response_flag() -> Flags {
+    Flags {
+        qr: true,
+        opcode: Opcode::Query,
+        aa: false,
+        tc: false,
+        rd: false,
+        ra: false,
+        ad: false,
+        cd: false,
+        rcode: RCode::NoError,
+    }
+}

--- a/src/question.rs
+++ b/src/question.rs
@@ -106,6 +106,10 @@ try_from_enum_to_integer! {
         OPENPGPKEY = 61,
         CSYNC = 62,
         ZONEMD = 63,
+        /// Service Binding
+        SVCB = 64,
+        /// Service Binding specific to the https and http schemes
+        HTTPS = 65,
 
         SPF = 99,
         UINFO = 100,

--- a/src/rr/draft_ietf_dnsop_svcb_https.rs
+++ b/src/rr/draft_ietf_dnsop_svcb_https.rs
@@ -1,0 +1,271 @@
+use std::cmp::Ordering;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::hash::{Hash, Hasher};
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use crate::rr::draft_ietf_dnsop_svcb_https::ServiceBindingMode::{Alias, Service};
+use crate::rr::{ToType, Type};
+use crate::DomainName;
+use std::collections::BTreeSet;
+
+/// A Service Binding record for locating alternative endpoints for a service.
+///
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ServiceBinding {
+    pub name: DomainName,
+    pub ttl: u32,
+
+    // The class is always IN (Internet, 0x0001)
+    /// The `SvcPriority` field, a value between 0 and 65535
+    /// SVCB resource records with a smaller priority SHOULD be given priority over resource records
+    /// with a larger value.
+    pub priority: u16,
+    pub target_name: DomainName,
+    pub parameters: BTreeSet<ServiceParameter>,
+    /// Indicates whether or not this is an HTTPS record (RFC section 8)
+    pub https: bool,
+}
+
+impl ToType for ServiceBinding {
+    fn to_type(&self) -> Type {
+        if self.https {
+            Type::HTTPS
+        } else {
+            Type::SVCB
+        }
+    }
+}
+
+/// The modes inferred from the `SvcPriority` field
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ServiceBindingMode {
+    /// "go to the target name and do another service binding query"
+    /// enables apex aliasing for participating clients
+    Alias,
+
+    /// Indicates that this record contains an arbitrary (IANA controlled) key value data store
+    /// The record contains anything the client _may_ need to know in order to connect to the server.
+    Service,
+}
+
+impl Display for ServiceBinding {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let record_type = if self.https { "HTTPS" } else { "SVCB" };
+        write!(
+            f,
+            "{} {} IN {} {} {}",
+            self.name, self.ttl, record_type, self.priority, self.target_name
+        )?;
+        self.parameters
+            .iter()
+            .try_for_each(|parameter| -> FmtResult {
+                write!(f, " ")?;
+                parameter.fmt(f)
+            })
+    }
+}
+
+impl ServiceBinding {
+    pub fn mode(&self) -> ServiceBindingMode {
+        if self.priority == 0 {
+            Alias
+        } else {
+            Service
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq)]
+pub enum ServiceParameter {
+    /// Mandatory keys in this resource record (service mode only)
+    MANDATORY {
+        /// the key IDs the client must support in order for this resource record to function properly
+        /// RFC section 7
+        key_ids: Vec<u16>,
+    },
+    /// Additional supported protocols
+    ALPN {
+        /// The default set of ALPNs, which SHOULD NOT be empty, e.g. "h3", "h2", "http/1.1".
+        alpn_ids: Vec<String>,
+    },
+    /// No support for default protocol
+    ///
+    /// When this is specified in a resource record, `ALPN` must also be specified in order to be
+    /// "self-consistent".
+    NO_DEFAULT_ALPN,
+    /// Port for alternative endpoint
+    PORT { port: u16 },
+    /// IPv4 address hints
+    IPV4_HINT { hints: Vec<Ipv4Addr> },
+    /// Encrypted ClientHello information (RFC Section 9)
+    ///
+    /// This conveys the ECH configuration of an alternative endpoint.
+    ECH { config_list: Vec<u8> },
+    /// IPv6 address hints
+    IPV6_HINT { hints: Vec<Ipv6Addr> },
+    /// Private use keys 65280-65534
+    PRIVATE { number: u16, wire_data: Vec<u8> },
+    /// Reserved ("Invalid key")
+    KEY_65535,
+}
+
+impl PartialEq for ServiceParameter {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_registered_number()
+            .eq(&other.get_registered_number())
+    }
+}
+
+impl Hash for ServiceParameter {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u16(self.get_registered_number())
+    }
+}
+
+impl PartialOrd for ServiceParameter {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ServiceParameter {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.get_registered_number()
+            .cmp(&other.get_registered_number())
+    }
+}
+
+impl ServiceParameter {
+    pub fn get_registered_number(&self) -> u16 {
+        match self {
+            ServiceParameter::MANDATORY { .. } => 0,
+            ServiceParameter::ALPN { .. } => 1,
+            ServiceParameter::NO_DEFAULT_ALPN => 2,
+            ServiceParameter::PORT { .. } => 3,
+            ServiceParameter::IPV4_HINT { .. } => 4,
+            ServiceParameter::ECH { .. } => 5,
+            ServiceParameter::IPV6_HINT { .. } => 6,
+            ServiceParameter::PRIVATE {
+                number,
+                wire_data: _,
+            } => *number,
+            ServiceParameter::KEY_65535 => 65535,
+        }
+    }
+
+    fn id_to_presentation_name(id: u16) -> String {
+        match id {
+            0 => "mandatory".to_string(),
+            1 => "alpn".to_string(),
+            2 => "no-default-alpn".to_string(),
+            3 => "port".to_string(),
+            4 => "ipv4hint".to_string(),
+            5 => "ech".to_string(),
+            6 => "ipv6hint".to_string(),
+            65535 => "reserved".to_string(),
+            number => format!("key{}", number),
+        }
+    }
+}
+
+/// Escape backslashes and commas in an ALPN ID
+fn escape_alpn(alpn: &str) -> String {
+    let mut result = String::new();
+    for char in alpn.chars() {
+        if char == '\\' {
+            result.push_str("\\\\\\");
+        } else if char == ',' {
+            result.push('\\');
+        }
+        result.push(char);
+    }
+    result
+}
+
+impl Display for ServiceParameter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            ServiceParameter::MANDATORY { key_ids } => {
+                let mut key_ids = key_ids.clone();
+                key_ids.sort_unstable();
+                let mandatory_keys = key_ids
+                    .iter()
+                    .map(|id| ServiceParameter::id_to_presentation_name(*id))
+                    .collect::<Vec<String>>()
+                    .join(",");
+
+                write!(f, "mandatory={}", mandatory_keys)
+            }
+            ServiceParameter::ALPN { alpn_ids } => {
+                let mut escape = false;
+                let mut escaped_ids = vec![];
+                for id in alpn_ids {
+                    let escaped = escape_alpn(id);
+                    if escaped != *id {
+                        escape |= true;
+                    }
+                    escaped_ids.push(escaped);
+                }
+                let value = escaped_ids.join(",");
+                if escape {
+                    write!(f, "alpn=\"{}\"", value)
+                } else {
+                    write!(f, "alpn={}", value)
+                }
+            }
+            ServiceParameter::NO_DEFAULT_ALPN => write!(f, "no-default-alpn"),
+            ServiceParameter::PORT { port } => write!(f, "port={}", port),
+            ServiceParameter::IPV4_HINT { hints } => {
+                write!(
+                    f,
+                    "ipv4hint={}",
+                    hints
+                        .iter()
+                        .map(|hint| hint.to_string())
+                        .collect::<Vec<String>>()
+                        .join(",")
+                )
+            }
+            ServiceParameter::ECH { config_list } => {
+                write!(f, "ech={}", base64::encode(config_list))
+            }
+            ServiceParameter::IPV6_HINT { hints } => {
+                write!(
+                    f,
+                    "ipv6hint=\"{}\"",
+                    hints
+                        .iter()
+                        .map(|hint| hint.to_string())
+                        .collect::<Vec<String>>()
+                        .join(",")
+                )
+            }
+            ServiceParameter::PRIVATE { number, wire_data } => {
+                let key = format!("key{}", number);
+                let value = String::from_utf8(wire_data.clone());
+                if let Ok(value) = value {
+                    write!(f, "{}={}", key, value)
+                } else {
+                    let mut escaped = vec![];
+                    for byte in wire_data {
+                        if *byte < b'0'
+                            || (*byte > b'9' && *byte < b'A')
+                            || (*byte > b'Z' && *byte < b'a')
+                            || *byte > b'z'
+                        {
+                            escaped.extend_from_slice(format!("\\{}", *byte).as_bytes());
+                        } else {
+                            escaped.push(*byte);
+                        }
+                    }
+                    if let Ok(value) = String::from_utf8(escaped) {
+                        write!(f, "{}=\"{}\"", key, value)
+                    } else {
+                        write!(f, "{}=\"{}\"", key, base64::encode(wire_data))
+                    }
+                }
+            }
+            ServiceParameter::KEY_65535 => write!(f, "reserved"),
+        }
+    }
+}

--- a/src/rr/enums.rs
+++ b/src/rr/enums.rs
@@ -3,6 +3,7 @@ pub use super::{
     L32, L64, LOC, LP, MB, MD, MF, MG, MINFO, MR, MX, NID, NIMLOC, NS, NSAP, NULL, OPT, PTR, PX,
     RP, RT, SOA, SRV, SSHFP, TXT, URI, WKS, X25,
 };
+use crate::rr::draft_ietf_dnsop_svcb_https::ServiceBinding;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 try_from_enum_to_integer! {
@@ -192,6 +193,15 @@ try_from_enum_to_integer! {
         CSYNC = 62,
         ZONEMD = 63,
 
+        /// The [service binding] resource record type.
+        ///
+        /// [service binding] https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/
+        SVCB = 64,
+        /// The [https] resource record type.
+        ///
+        /// [https] https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/
+        HTTPS = 65,
+
         SPF = 99,
         UINFO = 100,
         UID = 101,
@@ -272,6 +282,8 @@ pub enum RR {
     DS(DS),
     DNSKEY(DNSKEY),
     CAA(CAA),
+    SVCB(ServiceBinding),
+    HTTPS(ServiceBinding),
 }
 
 impl RR {
@@ -321,6 +333,8 @@ impl RR {
             RR::DS(ds) => Some(ds.ttl),
             RR::DNSKEY(dnskey) => Some(dnskey.ttl),
             RR::CAA(caa) => Some(caa.ttl),
+            RR::SVCB(svcb) => Some(svcb.ttl),
+            RR::HTTPS(https) => Some(https.ttl),
         }
     }
 
@@ -370,6 +384,8 @@ impl RR {
             RR::DS(ds) => Some(ds.class.clone()),
             RR::DNSKEY(dnskey) => Some(dnskey.class.clone()),
             RR::CAA(caa) => Some(caa.class.clone()),
+            RR::SVCB(_) => Some(Class::IN),
+            RR::HTTPS(_) => Some(Class::IN),
         }
     }
 }
@@ -421,6 +437,8 @@ impl Display for RR {
             RR::DS(ds) => ds.fmt(f),
             RR::DNSKEY(dnskey) => dnskey.fmt(f),
             RR::CAA(caa) => caa.fmt(f),
+            RR::SVCB(svcb) => svcb.fmt(f),
+            RR::HTTPS(https) => https.fmt(f),
         }
     }
 }

--- a/src/rr/mod.rs
+++ b/src/rr/mod.rs
@@ -44,6 +44,7 @@
 
 #[macro_use]
 mod macros;
+mod draft_ietf_dnsop_svcb_https;
 pub mod edns;
 mod enums;
 mod rfc_1035;
@@ -64,8 +65,11 @@ mod rfc_7043;
 mod rfc_7553;
 mod rfc_8659;
 mod subtypes;
+#[cfg(test)]
+mod tests;
 mod unknown;
 
+pub use draft_ietf_dnsop_svcb_https::{ServiceBinding, ServiceBindingMode, ServiceParameter};
 pub use edns::rfc_6891::OPT;
 pub use enums::{Class, ToType, Type, RR};
 pub use rfc_1035::{A, CNAME, HINFO, MB, MD, MF, MG, MINFO, MR, MX, NS, NULL, PTR, SOA, TXT, WKS};

--- a/src/rr/tests.rs
+++ b/src/rr/tests.rs
@@ -1,0 +1,268 @@
+use std::convert::TryFrom;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use crate::rr::{ServiceBinding, ServiceParameter};
+use crate::DomainName;
+use std::collections::BTreeSet;
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#aliasform
+#[test]
+fn test_https_alias_form() {
+    // given
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 7200,
+        priority: 0, // alias
+        target_name,
+        parameters: BTreeSet::default(),
+        https: true,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(
+        result,
+        "example.com. 7200 IN HTTPS 0 foo.example.com.".to_string()
+    );
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_svcb_use_the_ownername() {
+    // given
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::default();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: false,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(result, "example.com. 300 IN SVCB 1 .");
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_https_map_port() {
+    // given
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 7200,
+        priority: 16,
+        target_name,
+        parameters: vec![ServiceParameter::PORT { port: 53 }]
+            .into_iter()
+            .collect::<BTreeSet<ServiceParameter>>(),
+        https: true,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(
+        result,
+        "example.com. 7200 IN HTTPS 16 foo.example.com. port=53"
+    );
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_svcb_unregistered_key_value() {
+    // given
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: vec![ServiceParameter::PRIVATE {
+            number: 667,
+            wire_data: b"hello".to_vec(),
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(
+        result,
+        "example.com. 300 IN SVCB 1 foo.example.com. key667=hello"
+    );
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_https_unregistered_key_escaped_value() {
+    // given
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: vec![ServiceParameter::PRIVATE {
+            number: 667,
+            wire_data: b"hello\xd2qoo".to_vec(),
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: true,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(
+        result,
+        "example.com. 300 IN HTTPS 1 foo.example.com. key667=\"hello\\210qoo\""
+    );
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_svcb_ipv6_hints() {
+    // given
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 7200,
+        priority: 1,
+        target_name,
+        parameters: vec![ServiceParameter::IPV6_HINT {
+            hints: vec![
+                Ipv6Addr::from_str("2001:db8::1").unwrap(),
+                Ipv6Addr::from_str("2001:db8::53:1").unwrap(),
+            ],
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(
+        result,
+        "example.com. 7200 IN SVCB 1 foo.example.com. ipv6hint=\"2001:db8::1,2001:db8::53:1\""
+    );
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_https_ipv6_hint_in_ipv4_mapped_ipv6_format() {
+    // given
+    let domain_name = DomainName::try_from("example.com").unwrap();
+    let target_name = DomainName::try_from("foo.example.com").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: vec![ServiceParameter::IPV6_HINT {
+            hints: vec![Ipv6Addr::from_str("2001:db8:ffff:ffff:ffff:ffff:198.51.100.100").unwrap()],
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: true,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    // note IPv6 display rules are already well-defined so not changing that here
+    // this behaviour conforms to the robustness principle
+    assert_eq!(result,
+               "example.com. 300 IN HTTPS 1 foo.example.com. ipv6hint=\"2001:db8:ffff:ffff:ffff:ffff:c633:6464\"");
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_svcb_multiple_parameters_in_wrong_order() {
+    // given
+    let domain_name = DomainName::try_from("example.org").unwrap();
+    let target_name = DomainName::try_from("foo.example.org").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 7200,
+        priority: 16,
+        target_name,
+        parameters: vec![
+            // the parameters are deliberately specified in the wrong order
+            // they will be sorted correctly in the presentation format
+            ServiceParameter::ALPN {
+                alpn_ids: vec!["h2".to_string(), "h3-19".to_string()],
+            },
+            ServiceParameter::MANDATORY {
+                key_ids: vec![4, 1], // ipv4hint and alpn are mandatory
+            },
+            ServiceParameter::IPV4_HINT {
+                hints: vec![Ipv4Addr::from_str("192.0.2.1").unwrap()],
+            },
+        ]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: false,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(result,
+               "example.org. 7200 IN SVCB 16 foo.example.org. mandatory=alpn,ipv4hint alpn=h2,h3-19 ipv4hint=192.0.2.1");
+}
+
+/// Example from: https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md#serviceform
+#[test]
+fn test_https_alpn_with_escaped_values() {
+    // given
+    let domain_name = DomainName::try_from("example.org").unwrap();
+    let target_name = DomainName::try_from("foo.example.org").unwrap();
+    let service_binding = ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 16,
+        target_name,
+        parameters: vec![ServiceParameter::ALPN {
+            alpn_ids: vec!["f\\oo,bar".to_string(), "h2".to_string()],
+        }]
+        .into_iter()
+        .collect::<BTreeSet<ServiceParameter>>(),
+        https: true,
+    };
+
+    // when
+    let result = service_binding.to_string();
+
+    // then
+    assert_eq!(
+        result,
+        "example.org. 300 IN HTTPS 16 foo.example.org. alpn=\"f\\\\\\\\oo\\,bar,h2\""
+    );
+}

--- a/tests/class.rs
+++ b/tests/class.rs
@@ -1,9 +1,11 @@
 use dns_message_parser::rr::{
-    AFSDBSubtype, Class, ISDNAddress, PSDNAddress, SSHFPAlgorithm, SSHFPType, A, AAAA, AFSDB, APL,
-    CNAME, DNAME, EID, EUI48, EUI64, GPOS, HINFO, ISDN, KX, L32, L64, LP, MB, MD, MF, MG, MINFO,
-    MR, MX, NID, NIMLOC, NS, OPT, PTR, PX, RP, RR, RT, SA, SOA, SRV, SSHFP, TXT, URI, X25,
+    AFSDBSubtype, Class, ISDNAddress, PSDNAddress, SSHFPAlgorithm, SSHFPType, ServiceBinding, A,
+    AAAA, AFSDB, APL, CNAME, DNAME, EID, EUI48, EUI64, GPOS, HINFO, ISDN, KX, L32, L64, LP, MB, MD,
+    MF, MG, MINFO, MR, MX, NID, NIMLOC, NS, OPT, PTR, PX, RP, RR, RT, SA, SOA, SRV, SSHFP, TXT,
+    URI, X25,
 };
 use dns_message_parser::DomainName;
+use std::collections::BTreeSet;
 use std::convert::TryFrom;
 
 #[test]
@@ -587,4 +589,46 @@ fn rr_apl() {
         apitems,
     });
     assert_eq!(rr.get_class(), Some(Class::IN));
+}
+
+#[test]
+fn rr_svcb() {
+    // given
+    let domain_name = DomainName::try_from("www.example.com").unwrap();
+    let target_name = DomainName::try_from("service.example.com").unwrap();
+    let rr = RR::SVCB(ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: false,
+    });
+
+    // when
+    let class = rr.get_class();
+
+    // then
+    assert_eq!(class, Some(Class::IN));
+}
+
+#[test]
+fn rr_https() {
+    // given
+    let domain_name = DomainName::try_from("www.example.com").unwrap();
+    let target_name = DomainName::try_from("service.example.com").unwrap();
+    let rr = RR::HTTPS(ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: true,
+    });
+
+    // when
+    let class = rr.get_class();
+
+    // then
+    assert_eq!(class, Some(Class::IN));
 }

--- a/tests/question.rs
+++ b/tests/question.rs
@@ -42,3 +42,17 @@ fn decode_q_class_error() {
     let result = QClass::decode(bytes);
     assert!(result.is_err());
 }
+
+#[test]
+fn decode_q_type_svcb() {
+    let bytes = Bytes::copy_from_slice(&b"\x00\x40"[..]);
+    let q_type = QType::decode(bytes).unwrap();
+    assert_eq!(q_type, QType::SVCB);
+}
+
+#[test]
+fn decode_q_type_https() {
+    let bytes = Bytes::copy_from_slice(&b"\x00\x41"[..]);
+    let q_type = QType::decode(bytes).unwrap();
+    assert_eq!(q_type, QType::HTTPS);
+}

--- a/tests/ttl.rs
+++ b/tests/ttl.rs
@@ -1,9 +1,11 @@
 use dns_message_parser::rr::{
-    AFSDBSubtype, Class, ISDNAddress, PSDNAddress, SSHFPAlgorithm, SSHFPType, A, AAAA, AFSDB, APL,
-    CNAME, DNAME, EID, EUI48, EUI64, GPOS, HINFO, ISDN, KX, L32, L64, LP, MB, MD, MF, MG, MINFO,
-    MR, MX, NID, NIMLOC, NS, OPT, PTR, PX, RP, RR, RT, SA, SOA, SRV, SSHFP, TXT, URI, X25,
+    AFSDBSubtype, Class, ISDNAddress, PSDNAddress, SSHFPAlgorithm, SSHFPType, ServiceBinding, A,
+    AAAA, AFSDB, APL, CNAME, DNAME, EID, EUI48, EUI64, GPOS, HINFO, ISDN, KX, L32, L64, LP, MB, MD,
+    MF, MG, MINFO, MR, MX, NID, NIMLOC, NS, OPT, PTR, PX, RP, RR, RT, SA, SOA, SRV, SSHFP, TXT,
+    URI, X25,
 };
 use dns_message_parser::DomainName;
+use std::collections::BTreeSet;
 use std::convert::TryFrom;
 
 #[test]
@@ -587,4 +589,46 @@ fn rr_apl() {
         apitems,
     });
     assert_eq!(rr.get_ttl(), Some(300));
+}
+
+#[test]
+fn rr_svcb() {
+    // given
+    let domain_name = DomainName::try_from("www.example.com").unwrap();
+    let target_name = DomainName::try_from("service.example.com").unwrap();
+    let rr = RR::SVCB(ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: false,
+    });
+
+    // when
+    let ttl = rr.get_ttl();
+
+    // then
+    assert_eq!(ttl, Some(300));
+}
+
+#[test]
+fn rr_https() {
+    // given
+    let domain_name = DomainName::try_from("www.example.com").unwrap();
+    let target_name = DomainName::try_from("service.example.com").unwrap();
+    let rr = RR::HTTPS(ServiceBinding {
+        name: domain_name,
+        ttl: 300,
+        priority: 1,
+        target_name,
+        parameters: BTreeSet::default(),
+        https: true,
+    });
+
+    // when
+    let ttl = rr.get_ttl();
+
+    // then
+    assert_eq!(ttl, Some(300));
 }


### PR DESCRIPTION
This adds support for servicing binding resource records: SVCB, type 64
and HTTPS, type 65. This adds two new resource record enum variants:
`SVCB` and `HTTPS`. However, since the structure of those records are
nearly identical, only a single `ServiceBinding` struct is introduced.
Tests for encoding, decoding, and presentation formatting were added
based on the test vectors here:
https://github.com/MikeBishop/dns-alt-svc/blob/master/draft-ietf-dnsop-svcb-https.md
.

References:
* https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/
* https://github.com/MikeBishop/dns-alt-svc
* https://indico.dns-oarc.net/event/37/contributions/813/attachments/781/1365/SVCB_HTTPS_%20DNS-OARC%202021%20%281%29.pdf
* https://www.youtube.com/watch?v=K-2TIJ4h7tY&t=220s

Resolves: #13