### PR TITLE
Preserve case when parsing domain names

### DIFF
--- a/src/domain_name.rs
+++ b/src/domain_name.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::hash::{Hash, Hasher};
 use thiserror::Error;
 
 pub const DOMAIN_NAME_MAX_RECURSION: usize = 16;
@@ -16,7 +17,7 @@ pub enum DomainNameError {
     LabelDot,
 }
 
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, Clone, Eq)]
 pub struct DomainName(pub(super) String);
 
 impl DomainName {
@@ -62,11 +63,10 @@ impl DomainName {
             return Err(DomainNameError::LabelDot);
         }
 
-        let label = label.to_lowercase();
         if &self.0 == "." {
-            self.0.insert_str(0, &label);
+            self.0.insert_str(0, label);
         } else {
-            self.0.push_str(&label);
+            self.0.push_str(label);
             self.0.push('.');
         }
         Ok(())
@@ -109,14 +109,26 @@ impl AsRef<str> for DomainName {
     }
 }
 
+impl PartialEq<DomainName> for DomainName {
+    fn eq(&self, other: &DomainName) -> bool {
+        self.0.to_lowercase() == other.0.to_lowercase()
+    }
+}
+
 impl PartialEq<&str> for DomainName {
     fn eq(&self, other: &&str) -> bool {
-        self.0 == other.to_lowercase()
+        self.0.to_lowercase() == other.to_lowercase()
     }
 }
 
 impl Display for DomainName {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", self.0)
+    }
+}
+
+impl Hash for DomainName {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_lowercase().hash(state);
     }
 }

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -128,7 +128,7 @@ fn domain_name_eq() {
 fn domain_name_string_eq() {
     let domain_name = DomainName::try_from("Example.OrG.").unwrap();
     assert_eq!(domain_name, "example.org.");
-    assert_eq!(domain_name.as_ref(), "example.org.");
+    assert_eq!(domain_name.as_ref(), "Example.OrG.");
     assert_ne!(domain_name, "example.com.");
 }
 
@@ -136,5 +136,5 @@ fn domain_name_string_eq() {
 fn domain_name_from_string() {
     let domain_name = DomainName::try_from("Example.OrG.").unwrap();
     let domain_name = String::from(domain_name);
-    assert_eq!(&domain_name, "example.org.");
+    assert_eq!(&domain_name, "Example.OrG.");
 }


### PR DESCRIPTION
When implementing DNS servers, one might need to return
domain names in exactly the same case as was in the question.
For example, `dig eXamPle.cOm.` includes

```
;; ANSWER SECTION:
eXamPle.cOm.		20885	IN	A	93.184.216.34
```

Notice the answer section says `eXamPle.cOm` and not
`example.com`. This is currently not possible when using this
crate as it automatically converts to lowercase.

Fixes https://github.com/LinkTed/dns-message-parser/issues/12.